### PR TITLE
Fix compilation error (pytorch 1.11.0, cuda 11.6)

### DIFF
--- a/src/spmm.cu
+++ b/src/spmm.cu
@@ -29,6 +29,7 @@
 
 #include <cusparse.h>
 
+#include <ATen/core/Tensor.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/CUDAUtils.h>
 #include <c10/cuda/CUDACachingAllocator.h>


### PR DESCRIPTION
Original Fix from: https://github.com/NVIDIA/MinkowskiEngine/commit/c89b4cf1841fc04fbfb3b3386521cfc3d2f66cc4